### PR TITLE
Fix multiple subscriptions bug

### DIFF
--- a/js/kafka/kafka-consumer.js
+++ b/js/kafka/kafka-consumer.js
@@ -82,8 +82,6 @@ export class KafkaConsumer extends Consumer {
         await this.consumer.subscribe({ topic: topic });
         this.topicCallbacks[topic] = callback;
 
-        this.running = true;
-
         // run the consumer only if the flag is true, making it
         // possible to subscribe to several topics first and
         // then execute the consumer
@@ -116,6 +114,7 @@ export class KafkaConsumer extends Consumer {
                 ? this.eachBatchAutoResolve
                 : options.eachBatchAutoResolve;
 
+        this.running = true;
         this.consumer.run({
             autoCommit: autoCommit,
             autoCommitInterval: autoCommitInterval,

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -56,8 +56,6 @@ export class KafkaRetryConsumer extends KafkaConsumer {
         // retries processing previously failed messages every second
         setInterval(() => this._retry(options), 1000);
 
-        this.running = true;
-
         // run the consumer only if the flag is true, making it
         // possible to subscribe to several topics first and
         // then execute the consumer


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Problem | It was forcing the consumer to stop even if it was not running, since it was marking as running even if the `run` flag was `false`. |
| Animated GIF | -- |
