### PR TITLE
Add more type definitions

### DIFF
--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -1,9 +1,9 @@
-import { Item } from "./producer";
+import { Message } from "./producer";
 
 export declare class API {
     constructor(options?: Record<string, unknown>);
     static load(): Promise<void>;
-    trigger(topic: string, message: Item | Array<Item>, options?: Record<string, unknown>): Promise<void>;
+    trigger(topic: string, message: Message, options?: Record<string, unknown>): Promise<void>;
     build(): Promise<void>
     runConsumer(messageProcessor: Function, sendConfirmation?: Function, sendError?: Function): Promise<object>;
     sendMessages(messages: Array<string | object>, topic?: string): Promise<object>;

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -1,6 +1,7 @@
 export declare class API {
-    constructor();
-    load(): Promise<void>;
+    constructor(options?: Record<string, unknown>);
+    static load(): Promise<void>;
+    trigger(topic: string, message: Record<string, unknown>|Array|String, options?: Record<string, unknown>): Promise<void>;
     build(): Promise<void>
     runConsumer(messageProcessor: Function, sendConfirmation?: Function, sendError?: Function): Promise<object>;
     sendMessages(messages: Array<string | object>, topic?: string): Promise<object>;

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -1,8 +1,9 @@
 import { Message } from "./message";
 
 export declare class API {
-    constructor(options?: Record<string, unknown>);
     static load(): Promise<void>;
+
+    constructor(options?: Record<string, unknown>);
     trigger(topic: string, message: Message, options?: Record<string, unknown>): Promise<void>;
     build(): Promise<void>
     runConsumer(messageProcessor: Function, sendConfirmation?: Function, sendError?: Function): Promise<object>;

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -1,4 +1,4 @@
-import { Message } from "./producer";
+import { Message } from "./message";
 
 export declare class API {
     constructor(options?: Record<string, unknown>);

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -1,7 +1,9 @@
+import { Item } from "./producer";
+
 export declare class API {
     constructor(options?: Record<string, unknown>);
     static load(): Promise<void>;
-    trigger(topic: string, message: Record<string, unknown>|Array|String, options?: Record<string, unknown>): Promise<void>;
+    trigger(topic: string, message: Item | Array<Item>, options?: Record<string, unknown>): Promise<void>;
     build(): Promise<void>
     runConsumer(messageProcessor: Function, sendConfirmation?: Function, sendError?: Function): Promise<object>;
     sendMessages(messages: Array<string | object>, topic?: string): Promise<object>;

--- a/types/consumer.d.ts
+++ b/types/consumer.d.ts
@@ -1,4 +1,4 @@
-export interface Options {
+export interface ConsumeOptions {
     readonly onSuccess?: Function,
     readonly onError?: Function
 }
@@ -7,5 +7,5 @@ export declare class Consumer {
     constructor();
     connect(): Promise<void>;
     disconnect(): Promise<void>
-    consume(topic: string, callback: Function, options?: Options): Promise<object>;
+    consume(topic: string, callback: Function, options?: ConsumeOptions): Promise<object>;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,4 @@
 export * from "./base";
 export * from "./consumer";
+export * from "./message";
 export * from "./producer";

--- a/types/message.d.ts
+++ b/types/message.d.ts
@@ -1,0 +1,2 @@
+export type Item = string | object;
+export type Message = Item | Array<Item>;

--- a/types/producer.d.ts
+++ b/types/producer.d.ts
@@ -1,10 +1,9 @@
+import { Message } from "./message";
+
 export interface ProduceOptions {
     readonly onSuccess?: Function,
     readonly onError?: Function
 }
-
-export type Item = string | object;
-export type Message = Item | Array<Item>;
 
 export declare class Producer {
     constructor();

--- a/types/producer.d.ts
+++ b/types/producer.d.ts
@@ -1,4 +1,4 @@
-export interface Options {
+export interface ProduceOptions {
     readonly onSuccess?: Function,
     readonly onError?: Function
 }
@@ -7,5 +7,5 @@ export declare class Producer {
     constructor();
     connect(): Promise<void>;
     disconnect(): Promise<void>
-    produce(topic: string, messages: string | object | Array<string | object>, options?: Options): Promise<object>;
+    produce(topic: string, messages: string | object | Array<string | object>, options?: ProduceOptions): Promise<object>;
 }

--- a/types/producer.d.ts
+++ b/types/producer.d.ts
@@ -4,10 +4,11 @@ export interface ProduceOptions {
 }
 
 export type Item = string | object;
+export type Message = Item | Array<Item>;
 
 export declare class Producer {
     constructor();
     connect(): Promise<void>;
     disconnect(): Promise<void>
-    produce(topic: string, message: Item | Array<Item>, options?: ProduceOptions): Promise<object>;
+    produce(topic: string, message: Message, options?: ProduceOptions): Promise<object>;
 }

--- a/types/producer.d.ts
+++ b/types/producer.d.ts
@@ -3,9 +3,11 @@ export interface ProduceOptions {
     readonly onError?: Function
 }
 
+export type Item = string | object;
+
 export declare class Producer {
     constructor();
     connect(): Promise<void>;
     disconnect(): Promise<void>
-    produce(topic: string, messages: string | object | Array<string | object>, options?: ProduceOptions): Promise<object>;
+    produce(topic: string, message: Item | Array<Item>, options?: ProduceOptions): Promise<object>;
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/16 |
| Dependencies | --- |
| Decisions | These type definitions will allow RIPE Twitch to use RIPE Bus API (JS) <br> New functions are exposed, some signatures are corrected, clashing interfaces corrected as well. <br> Regarding this last topic, I change `Options` to produce and consume options instead of refactoring them into a separate file because I think they may evolve differently, with produce options differing from the consume ones. <br> I did not provide more strict typing to these two because they vary with the producer and/or consumer adapter used, so I kept them as generic as possible |

