### PR TITLE
fix: fix typo

### DIFF
--- a/js/kafka/kafka-consumer.js
+++ b/js/kafka/kafka-consumer.js
@@ -130,7 +130,7 @@ export class KafkaConsumer extends Consumer {
                     try {
                         await this._processMessage(message, batch.topic, options);
                     } catch (err) {
-                        console.err(`Problem handling message ${message} (${err})`);
+                        console.error(`Problem handling message ${message} (${err})`);
                     } finally {
                         await heartbeat();
                     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Came across this while testing, the message format was incorrect and the error was trying to be logged with `console.err` instead of `console.error` |
