### PR TITLE
Filter events by name

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -74,13 +74,13 @@ export class API {
         return this.busAdapter[0].toUpperCase() + this.busAdapter.slice(1);
     }
 
-    async _buildProducer() {
-        this.producer = new adapters[this.adapter + "Producer"](this);
+    async _buildProducer(options = {}) {
+        this.producer = new adapters[this.adapter + "Producer"](this, options);
         await this.producer.connect();
     }
 
-    async _buildConsumer() {
-        this.consumer = new adapters[this.adapter + "Consumer"](this);
+    async _buildConsumer(options = {}) {
+        this.consumer = new adapters[this.adapter + "Consumer"](this, options);
         await this.consumer.connect();
     }
 }

--- a/js/consumer.js
+++ b/js/consumer.js
@@ -3,6 +3,7 @@ import { NotImplementedError } from "yonius";
 export class Consumer {
     constructor(owner, options = {}) {
         this.owner = owner;
+        this.events = Array.isArray(options.events) ? options.events : [];
     }
 
     async connect() {

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -82,15 +82,14 @@ export class KafkaRetryConsumer extends KafkaConsumer {
         const retries = options.retries === undefined ? this.retries : options.retries;
         const retryDelay = options.retryDelay === undefined ? this.retryDelay : options.retryDelay;
 
-        const parsedMessage = JSON.parse(message.value.toString());
         try {
-            await this.topicCallbacks[topic](parsedMessage, topic);
+            await this.topicCallbacks[topic](message, topic);
         } catch (err) {
             // if the message processing fails, the message is
             // added to a retry buffer that will retry in an
             // exponentially increasing delay
             this.retryBuffer.push({
-                ...parsedMessage,
+                ...message,
                 firstFailure: Date.now(),
                 lastRetry: Date.now(),
                 topic: topic,
@@ -102,8 +101,8 @@ export class KafkaRetryConsumer extends KafkaConsumer {
         }
 
         if (!options.autoConfirm) return;
-        if (options.onSuccess) options.onSuccess(parsedMessage, topic);
-        else if (options.autoConfirm) this._onSuccess(parsedMessage, topic);
+        if (options.onSuccess) options.onSuccess(message, topic);
+        else if (options.autoConfirm) this._onSuccess(message, topic);
     }
 
     /**


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-docs/issues/516 |
| Dependencies | -- |
| Decisions | - `bind` now allows the passage of the events we which to process. The consumer skips message processing if not interested. E.g.: `await bus.bind("order", { events: ["order.created", "order.sent"] })` <br>- Options were being passed to `buildConsumer` and `buildProducer` but these did not declare the `options` argument, so I added it since it is a bug and I needed the options to pass along to set event filtering.<br>- Message is now parsed and then sent to `processMessage` because before entering `processMessage` the event is checked. Only then if within our interest is it processed.|
