### PR TITLE
Default on success

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -1,5 +1,5 @@
 import * as os from "os";
-import { conf, load } from "yonius";
+import { conf, load, YoniusError } from "yonius";
 import { KafkaProducer, KafkaConsumer, KafkaRetryConsumer, KafkaRetryProducer } from "./kafka";
 
 const adapters = {
@@ -74,7 +74,14 @@ export class API {
             options = { autoConfirm: true, run: true, ...this.options };
         } else if (typeof options === "object") {
             options = { autoConfirm: true, run: true, ...this.options, ...options };
+        } else {
+            throw new YoniusError("Invalid options type");
         }
+
+        // updates the on success event handler defaulting to a standard
+        // auto confirm implementation in case no on success is defined
+        const onSuccessDefault = (message, topic) => options.autoConfirm && this.trigger("confirmation.success", message);
+        options.onSuccess = options.onSuccess === undefined ? onSuccessDefault : options.onSuccess;
 
         await this._ensureConsumer();
 

--- a/js/kafka/kafka-consumer.js
+++ b/js/kafka/kafka-consumer.js
@@ -180,7 +180,7 @@ export class KafkaConsumer extends Consumer {
      * variables and callback methods.
      */
     _confirmMessage(message, topic, options) {
-        if (options.onSuccess) options.onSuccess(message, topic);
+        if (options.onSuccess && topic) options.onSuccess(message, topic);
         else if (options.autoConfirm) this.owner.trigger("confirmation.success", message);
     }
 

--- a/js/kafka/kafka-consumer.js
+++ b/js/kafka/kafka-consumer.js
@@ -167,8 +167,19 @@ export class KafkaConsumer extends Consumer {
      */
     async _processMessage(message, topic, options) {
         await this.topicCallbacks[topic](message, topic);
+        if (options.autoConfirm) this._confirmMessage(message, topic, options);
+    }
 
-        if (!options.autoConfirm) return;
+    /**
+     * Confirms the message. Uses either the default confirmation behavior or a custom
+     * `onSuccess` callback.
+     *
+     * @param {Object} message Message consumed by the consumer.
+     * @param {String} topic Topic where the message was consumed.
+     * @param {Object} options Object that contains configuration
+     * variables and callback methods.
+     */
+    _confirmMessage(message, topic, options) {
         if (options.onSuccess) options.onSuccess(message, topic);
         else if (options.autoConfirm) this.owner.trigger("confirmation.success", message);
     }

--- a/js/kafka/kafka-consumer.js
+++ b/js/kafka/kafka-consumer.js
@@ -180,7 +180,7 @@ export class KafkaConsumer extends Consumer {
      * variables and callback methods.
      */
     _confirmMessage(message, topic, options) {
-        if (options.onSuccess && topic) options.onSuccess(message, topic);
+        if (options.onSuccess) options.onSuccess(message, topic);
         else if (options.autoConfirm) this.owner.trigger("confirmation.success", message);
     }
 

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -100,7 +100,7 @@ export class KafkaRetryConsumer extends KafkaConsumer {
         }
 
         if (!options.autoConfirm) return;
-        this._confirmMessage(message, topic, options)
+        this._confirmMessage(message, topic, options);
     }
 
     /**
@@ -136,7 +136,8 @@ export class KafkaRetryConsumer extends KafkaConsumer {
                 i--;
 
                 if (!options.autoConfirm) continue;
-                this._confirmMessage(message, topic, options)
+                if (options.onError) options.onError(message);
+                else this.owner.trigger("error", message);
                 continue;
             }
 
@@ -169,7 +170,7 @@ export class KafkaRetryConsumer extends KafkaConsumer {
             i--;
 
             if (!options.autoConfirm) continue;
-            this._confirmMessage(message, topic, options)
+            this._confirmMessage(message, undefined, options);
         }
     }
 

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -99,8 +99,7 @@ export class KafkaRetryConsumer extends KafkaConsumer {
             return;
         }
 
-        if (!options.autoConfirm) return;
-        this._confirmMessage(message, topic, options);
+        if (options.onSuccess) options.onSuccess(message, topic);
     }
 
     /**
@@ -169,8 +168,7 @@ export class KafkaRetryConsumer extends KafkaConsumer {
             await this._updateBufferFile();
             i--;
 
-            if (!options.autoConfirm) continue;
-            this._confirmMessage(message, undefined, options);
+            if (options.onSuccess) options.onSuccess(message, message.topic);
         }
     }
 

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -101,7 +101,7 @@ export class KafkaRetryConsumer extends KafkaConsumer {
 
         if (!options.autoConfirm) return;
         if (options.onSuccess) options.onSuccess(message, topic);
-        else if (options.autoConfirm) this._onSuccess(message, topic);
+        else if (options.autoConfirm) this.owner.trigger("confirmation.success", message);
     }
 
     /**
@@ -170,9 +170,9 @@ export class KafkaRetryConsumer extends KafkaConsumer {
             await this._updateBufferFile();
             i--;
 
-            if (!options.autoConfirm) continue;
+            if (!options.autoConfirm) return;
             if (options.onSuccess) options.onSuccess(message);
-            else this._onSuccess(message);
+            else if (options.autoConfirm) this.owner.trigger("confirmation.success", message);
         }
     }
 

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -170,9 +170,9 @@ export class KafkaRetryConsumer extends KafkaConsumer {
             await this._updateBufferFile();
             i--;
 
-            if (!options.autoConfirm) return;
+            if (!options.autoConfirm) continue;
             if (options.onSuccess) options.onSuccess(message);
-            else if (options.autoConfirm) this.owner.trigger("confirmation.success", message);
+            else this.owner.trigger("confirmation.success", message);
         }
     }
 

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -100,8 +100,7 @@ export class KafkaRetryConsumer extends KafkaConsumer {
         }
 
         if (!options.autoConfirm) return;
-        if (options.onSuccess) options.onSuccess(message, topic);
-        else if (options.autoConfirm) this.owner.trigger("confirmation.success", message);
+        this._confirmMessage(message, topic, options)
     }
 
     /**
@@ -137,8 +136,7 @@ export class KafkaRetryConsumer extends KafkaConsumer {
                 i--;
 
                 if (!options.autoConfirm) continue;
-                if (options.onError) options.onError(message);
-                else this.owner.trigger("error", message);
+                this._confirmMessage(message, topic, options)
                 continue;
             }
 
@@ -171,8 +169,7 @@ export class KafkaRetryConsumer extends KafkaConsumer {
             i--;
 
             if (!options.autoConfirm) continue;
-            if (options.onSuccess) options.onSuccess(message);
-            else this.owner.trigger("confirmation.success", message);
+            this._confirmMessage(message, topic, options)
         }
     }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | `_onSuccess` was the default success handler, deleted in the previous PR; currently if no onSuccess is specified the message is not processed |

