### PR TITLE
Optional metadata fields

### DIFF
--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -13,11 +13,11 @@ export type ApiOptions = {
 }
 
 export type TriggerOptions = {
-    name: string,
+    name?: string,
     origin?: string,
-    hostname: string,
-    datatype: string,
-    timestamp: number
+    hostname?: string,
+    datatype?: string,
+    timestamp?: number
 }
 
 export type BindOptions = {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Event metadata can be passed as trigger options but we should be able to override only some fields and let the others default to whatever ripe-bus-api defaults them to. |

