### PR TITLE
Propagate options

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -97,7 +97,7 @@ export class API {
 
         // makes sure that there's a valid consumer instance that is
         // connected to the proper remote provider
-        await this._ensureConsumer();
+        await this._ensureConsumer(options);
 
         // start the consuming process for the requested topic
         // this may block the current execution into an event loop
@@ -119,33 +119,33 @@ export class API {
         return this.busAdapter[0].toUpperCase() + this.busAdapter.slice(1);
     }
 
-    async _getProducer() {
-        await this._ensureProducer();
+    async _getProducer(options = {}) {
+        await this._ensureProducer(options);
         return this.producer;
     }
 
-    async _getConsumer() {
-        await this._ensureConsumer();
+    async _getConsumer(options = {}) {
+        await this._ensureConsumer(options);
         return this.consumer;
     }
 
-    async _ensureProducer() {
+    async _ensureProducer(options = {}) {
         if (this.producer) return;
-        await this._buildProducer();
+        await this._buildProducer(options);
     }
 
-    async _ensureConsumer() {
+    async _ensureConsumer(options = {}) {
         if (this.consumer) return;
-        await this._buildConsumer();
+        await this._buildConsumer(options);
     }
 
-    async _buildProducer() {
-        this.producer = await adapters[this.adapter + "Producer"].build(this);
+    async _buildProducer(options = {}) {
+        this.producer = await adapters[this.adapter + "Producer"].build(this, options);
         await this.producer.connect();
     }
 
-    async _buildConsumer() {
-        this.consumer = await adapters[this.adapter + "Consumer"].build(this);
+    async _buildConsumer(options = {}) {
+        this.consumer = await adapters[this.adapter + "Consumer"].build(this, options);
         await this.consumer.connect();
     }
 }

--- a/js/consumer.js
+++ b/js/consumer.js
@@ -5,7 +5,7 @@ export class Consumer {
         this.owner = owner;
     }
 
-    static async build(options = {}) {
+    static async build(owner, options = {}) {
         throw new NotImplementedError();
     }
 

--- a/js/kafka/kafka-consumer.js
+++ b/js/kafka/kafka-consumer.js
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from "uuid";
 import { conf } from "yonius";
 
 import { KafkaClient } from "./kafka-client";
@@ -11,7 +12,7 @@ export class KafkaConsumer extends Consumer {
     }
 
     async init(owner, options = {}) {
-        this.groupId = conf("KAFKA_CONSUMER_GROUP_ID", "ripe-kafka-consumer");
+        this.groupId = conf("KAFKA_CONSUMER_GROUP_ID", `ripe-kafka-consumer-${uuidv4()}`);
         this.minBytes = conf("KAFKA_CONSUMER_FETCH_MIN_BYTES", 1);
         this.maxBytes = conf("KAFKA_CONSUMER_FETCH_MAX_BYTES", 1024 * 1024);
         this.maxWaitTimeInMs = conf("KAFKA_CONSUMER_FETCH_MAX_WAIT", 100);

--- a/js/kafka/kafka-consumer.js
+++ b/js/kafka/kafka-consumer.js
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from "uuid";
 import { conf } from "yonius";
 
 import { KafkaClient } from "./kafka-client";
@@ -7,12 +6,12 @@ import { Consumer } from "../consumer";
 export class KafkaConsumer extends Consumer {
     static async build(owner, options = {}) {
         const instance = new this(owner, options);
-        await instance.init(options);
+        await instance.init(owner, options);
         return instance;
     }
 
     async init(owner, options = {}) {
-        this.groupId = conf("KAFKA_CONSUMER_GROUP_ID", `ripe-kafka-consumer-${uuidv4()}`);
+        this.groupId = conf("KAFKA_CONSUMER_GROUP_ID", "ripe-kafka-consumer");
         this.minBytes = conf("KAFKA_CONSUMER_FETCH_MIN_BYTES", 1);
         this.maxBytes = conf("KAFKA_CONSUMER_FETCH_MAX_BYTES", 1024 * 1024);
         this.maxWaitTimeInMs = conf("KAFKA_CONSUMER_FETCH_MAX_WAIT", 100);

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "dependencies": {
         "kafkajs": "^1.15.0",
         "sinon": "^9.2.4",
-        "uuid": "^8.3.2",
         "yonius": "^0.7.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,26 +49,26 @@
     },
     "dependencies": {
         "kafkajs": "^1.15.0",
-        "sinon": "^9.2.3",
+        "sinon": "^9.2.4",
         "uuid": "^8.3.2",
-        "yonius": "^0.6.3"
+        "yonius": "^0.7.2"
     },
     "devDependencies": {
-        "@babel/core": "^7.12.10",
-        "@babel/preset-env": "^7.12.11",
-        "@rollup/plugin-babel": "^5.2.2",
-        "@rollup/plugin-commonjs": "^17.0.0",
+        "@babel/core": "^7.13.1",
+        "@babel/preset-env": "^7.13.5",
+        "@rollup/plugin-babel": "^5.3.0",
+        "@rollup/plugin-commonjs": "^17.1.0",
         "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^11.1.0",
-        "eslint": "^7.17.0",
+        "@rollup/plugin-node-resolve": "^11.2.0",
+        "eslint": "^7.20.0",
         "eslint-config-hive": "^0.5.3",
-        "mocha": "^8.2.1",
+        "mocha": "^8.3.0",
         "mocha-cli": "^1.0.1",
-        "npm-check-updates": "^10.2.5",
+        "npm-check-updates": "^11.1.9",
         "prettier": "^2.2.1",
         "prettier-config-hive": "^0.1.7",
-        "rollup": "^2.36.1",
+        "rollup": "^2.39.1",
         "rollup-plugin-node-polyfills": "^0.2.1",
-        "sort-package-json": "^1.48.1"
+        "sort-package-json": "^1.49.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "dependencies": {
         "kafkajs": "^1.15.0",
         "sinon": "^9.2.3",
+        "uuid": "^8.3.2",
         "yonius": "^0.6.3"
     },
     "devDependencies": {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | `ensure*` and related methods should receive options and propagate them. `build` receives the owner and `init` expects it |

