### PR TITLE
feat: allow multiple callbacks for each topic and its override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Allow multiple callbacks for each topic subscription
-* Added `override` option to override the previous callbacks made for a `bind` on a topic
+* Allow callbacks for each event of each topic so that it is possible to sucbscribe to the same topic for different events
+* Added `override` option to override the previous callbacks made for a topic subscription
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Allow multiple callbacks for each topic subscription
+* Added `override` option to override the previous callbacks made for a `bind` on a topic
 
 ### Changed
 

--- a/js/kafka/kafka-consumer.js
+++ b/js/kafka/kafka-consumer.js
@@ -166,12 +166,6 @@ export class KafkaConsumer extends Consumer {
             options.eachBatchAutoResolve === undefined
                 ? this.eachBatchAutoResolve
                 : options.eachBatchAutoResolve;
-        const events =
-            options.events === undefined
-                ? null
-                : Array.isArray(options.events)
-                ? options.events
-                : [options.events];
 
         this.running = true;
         await this.consumer.run({


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Allow multiple callbacks for each topic and event and its override. This feature is useful when there are several binds made to the same topic for different events (for example for different logic for each specific event). This feature is important to @NFSS10 issue https://github.com/ripe-tech/ripe-pulse/issues/260. |
| Dependencies | -- |
| Decisions | - Save topic callbacks as an object that contains the callbacks for the topic for each event, so that it is possible to save several callbacks for each bind to the same topic.<br>- Use consumer parameter `override` to override the previous callbacks and use only the one given in the current bind.<br>- Moved message event verification to `_processMessage` since the filtering of the callbacks is made there according to the message event, so its not necessary to have this logic duplicated. <br><br>Note: will make a PR later to improve the documentation of the consumer and producer options. |
| Animated GIF | Below an example |

https://user-images.githubusercontent.com/25725586/140750926-3e9b7554-e7bc-4941-9491-6ef79b073486.mp4
