### PR TITLE
feat: allow multiple callbacks for each topic and its override for kafka retry consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support for multiple events for each topics on the kafka retry consumer
 
 ### Changed
 
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Allow callbacks for each event of each topic so that it is possible to sucbscribe to the same topic for different events
+* Allow callbacks for each event of each topic so that it is possible to subscribe to the same topic for different events
 * Added `override` option to override the previous callbacks made for a topic subscription
 
 ## [0.4.3] - 2021-05-31

--- a/js/kafka/kafka-consumer.js
+++ b/js/kafka/kafka-consumer.js
@@ -217,7 +217,7 @@ export class KafkaConsumer extends Consumer {
         // retrieves all the callbacks for the provided: message, topic
         // and event to be able to call them latter
         const callbackPromises = Object.entries(this.topicCallbacks[topic])
-                .filter(([event, callback]) => event === message.name || event === "*")
+            .filter(([event, callback]) => event === message.name || event === "*")
             .map(([event, callback]) => callback(message, topic));
 
         // returns the control flow immediately in case there

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -246,10 +246,12 @@ export class KafkaRetryConsumer extends KafkaConsumer {
 
         // if the file exists, reads it and populates
         // the retryBuffer, if not ignores and returns
-        const data = await fs.promises.readFile(`${this.retryPersistenceDir}/retry.json`, {
-            encoding: "utf-8"
-        });
-        this.retryBuffer = JSON.parse(data);
+        try {
+            const data = await fs.promises.readFile(`${this.retryPersistenceDir}/retry.json`, {
+                encoding: "utf-8"
+            });
+            this.retryBuffer = JSON.parse(data);
+        } catch {}
     }
 
     /**

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -65,6 +65,8 @@ export class KafkaRetryConsumer extends KafkaConsumer {
             topics.map(async topic => await this.consumer.subscribe({ topic: topic }))
         );
 
+        // normalizes the events value as a sequence making sure that if a basic
+        // type is provided it's encapsulated as an array
         const events =
             options.events === undefined
                 ? null
@@ -224,8 +226,12 @@ export class KafkaRetryConsumer extends KafkaConsumer {
         // valid callbacks called for it
         if (callbackPromises.length === 0) return;
 
+        // waits for all the callback promises to be fulfilled
+        // (keep in mind that execution is done in parallel)
         await Promise.all(callbackPromises);
 
+        // in case an on success callback is defined in the options
+        // object then such callback is called
         if (options.onSuccess) options.onSuccess(message, topic);
     }
 

--- a/js/kafka/kafka-retry-consumer.js
+++ b/js/kafka/kafka-retry-consumer.js
@@ -246,12 +246,10 @@ export class KafkaRetryConsumer extends KafkaConsumer {
 
         // if the file exists, reads it and populates
         // the retryBuffer, if not ignores and returns
-        try {
-            const data = await fs.promises.readFile(`${this.retryPersistenceDir}/retry.json`, {
-                encoding: "utf-8"
-            });
-            this.retryBuffer = JSON.parse(data);
-        } catch {}
+        const data = await fs.promises.readFile(`${this.retryPersistenceDir}/retry.json`, {
+            encoding: "utf-8"
+        });
+        this.retryBuffer = JSON.parse(data);
     }
 
     /**


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Same as https://github.com/ripe-tech/ripe-bus-api-js/pull/24 but for Kafka Retry Consumer. |
| Animated GIF | -- |
