### PR TITLE
fix: remove eslint problems dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy
     strategy:
       matrix:
-        node-version: [10]
+        node-version: [12]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [10, 11, 12, 13, 14]
+        node-version: [12, 13, 14, 16, 17, 18]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Bump dependencies
 
 ### Fixed
 
-*
+* Fix eslint dependencies problems
 
 ## [0.5.0] - 2021-11-22
 

--- a/package.json
+++ b/package.json
@@ -48,28 +48,33 @@
         "watch": "rollup -c -w"
     },
     "dependencies": {
-        "crypto-js": "^4.0.0",
-        "kafkajs": "^1.15.0",
+        "crypto-js": "^4.1.1",
+        "kafkajs": "^1.16.0",
         "sinon": "^9.2.4",
         "uuid": "^8.3.2",
-        "yonius": "^0.7.2"
+        "yonius": "^0.11.7"
     },
     "devDependencies": {
-        "@babel/core": "^7.13.1",
-        "@babel/preset-env": "^7.13.5",
-        "@rollup/plugin-babel": "^5.3.0",
-        "@rollup/plugin-commonjs": "^17.1.0",
+        "@babel/core": "^7.18.2",
+        "@babel/preset-env": "^7.18.2",
+        "@rollup/plugin-babel": "^5.3.1",
+        "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^11.2.0",
-        "eslint": "^7.20.0",
-        "eslint-config-hive": "^0.5.3",
-        "mocha": "^8.3.0",
+        "@rollup/plugin-node-resolve": "^13.3.0",
+        "eslint": "^8.16.0",
+        "eslint-config-hive": "^0.5.8",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-mocha": ">=10.0.0 && <10.0.3",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "mocha": "^9.2.2",
         "mocha-cli": "^1.0.1",
-        "npm-check-updates": "^11.1.9",
-        "prettier": "^2.2.1",
+        "npm-check-updates": "^13.0.3",
+        "prettier": "^2.6.2",
         "prettier-config-hive": "^0.1.7",
-        "rollup": "^2.39.1",
+        "rollup": "^2.74.1",
         "rollup-plugin-node-polyfills": "^0.2.1",
-        "sort-package-json": "^1.49.0"
+        "sort-package-json": "^1.57.0"
     }
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Similar to https://github.com/ripe-tech/ripe-components-vue/pull/596 |
| Dependencies | |
| Decisions | - Port `eslint-config-hive` dependencies<br>- Lock `eslint-plugin-mocha` to `10.0.3` due to problem with mocha and ramda packages<br>- Bump github workflow node versions |
| Animated GIF | -- |
